### PR TITLE
Fix gzip check in rule `ffpefilter_mafs`

### DIFF
--- a/workflow/rules/ffpe.smk
+++ b/workflow/rules/ffpe.smk
@@ -230,8 +230,9 @@ rule ffpefilter_mafs:
     container:
         config['images']['vcf2maf'] 
     shell: """
-    if [ $file == *.vcf.gz ] ; then
-       zcat {input.filtered_vcf} > {output.filtered_vcf}
+    filetype=$(file -b --mime-type {input.filtered_vcf})
+    if [ $filetype == "application/gzip" ] ; then
+        zcat {input.filtered_vcf} > {output.filtered_vcf}
     else 
         {input.filtered_vcf} > {output.filtered_vcf}
     fi


### PR DESCRIPTION
The previous code had a syntax error and also used the file extension rather than the file type to check whether it was compressed.

With this fix the pipeline now runs to completion.