### PR TITLE
On hotfix: add pre-commit config to enforce conventional commits style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+default_install_hook_types: [pre-commit, commit-msg]
+default_stages: [pre-commit]
+repos:
+  # enforce commit format
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v2.3.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: []


### PR DESCRIPTION
This pre-commit config file contains a git hook to enforce the conventional commits style. After you pull these changes locally and install [pre-commit](https://pre-commit.com/) (via pip, conda, or brew), install this hook with `pre-commit install`. Then it will check your commit message every time you attempt to commit and throw an error if it doesn't follow [conventional commits guidelines](https://www.conventionalcommits.org/).

(I accidentally opened #35 against `main` instead of `hotfix`)