### PR TITLE
Hotfix: set tmp dir dynamically

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -11,7 +11,7 @@
       "GERMLINE": "false",
       "FFPE_FILTER": "false",
       "CNV_CALLING": "false",
-      "tmpdisk": "/lscratch/$SLURM_JOBID/",
+      "tmpdisk": "",
       "genome": ""
     },
     "input_params_test": {

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -381,6 +381,25 @@ if 'CNV_CALLING' in config['input_params']:
             config['input_params']['PAIRS_FILE'] != "None"):
                 cnv_sample_list=pairs_ids
 
+# handle different temp dir locations depending on platform
+user_tmpdisk = config['input_params']['tmpdisk']
+def set_tmp():
+    shell = r"""
+if [ ! -z {user_tmpdisk} ] && [ -d {user_tmpdisk} ]; then
+    echo "Using user-provided tmpdisk"
+    tmpdisk={user_tmpdisk}
+elif [ ! -z ${{SLURM_JOBID:-}} ] && [ -d /lscratch/$SLURM_JOBID ]; then
+    tmpdisk=/lscratch/$SLURM_JOBID
+else
+    tmpdisk=/dev/shm
+fi
+tmp=$tmpdisk/{random_str}
+mkdir -p $tmp
+trap 'rm -rf "$tmp"' EXIT
+"""
+    return shell.format(user_tmpdisk=user_tmpdisk, random_str = str(uuid.uuid4()))
+
+
 #### July 28, 2021
 ## When I tried to run large data set through this pipeline (224 samples from CCLE),
 ## I was contacted by Biowulf staff pointing out that I was running too many short jobs.

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -8,6 +8,7 @@ import re
 import sys
 import glob
 import datetime
+import uuid
 
 ## FROM: https://github.com/skchronicles/RNA-seek/blob/main/rna-seek
 def rename(filename):

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -94,7 +94,7 @@ rule kraken:
         rname  ='kraken',
         outdir = os.path.join(output_qcdir, "kraken"),
         bacdb  = config['references']['KRAKENBACDB'],
-        localdisk = config['input_params']['tmpdisk']
+        set_tmp = set_tmp()
     envmodules:
         config['tools']['kraken']['modname'],
         config['tools']['kronatools']['modname']
@@ -104,8 +104,7 @@ rule kraken:
     # Setups temporary directory for
     # intermediate files with built-in 
     # mechanism for deletion on exit
-    tmp=$(mktemp -d -p "{params.localdisk}")
-    trap 'rm -rf "${{tmp}}"' EXIT
+    {params.set_tmp}
 
     # Copy kraken2 db to local node storage to reduce filesystem strain
     cp -rv {params.bacdb} ${{tmp}}

--- a/workflow/rules/somatic_snps.common.smk
+++ b/workflow/rules/somatic_snps.common.smk
@@ -74,7 +74,7 @@ rule mutect2_filter:
         ver_gatk = config['tools']['gatk4']['version'],
         ver_bcftools = config['tools']['bcftools']['version'],
         rname = 'mutect2_filter',
-        tmpdir = config['input_params']['tmpdisk'],
+        set_tmp = set_tmp(),
     threads: 2
     envmodules:
         config['tools']['gatk4']['modname'],
@@ -85,8 +85,7 @@ rule mutect2_filter:
     # Setups temporary directory for
     # intermediate files with built-in 
     # mechanism for deletion on exit
-    tmp=$(mktemp -d -p "{params.tmpdir}")
-    trap 'rm -rf "${{tmp}}"' EXIT
+    {params.set_tmp}
 
     statfiles="--stats $(echo "{input.statsfiles}" | sed -e 's/ / --stats /g')"
     
@@ -154,7 +153,7 @@ rule somatic_merge_callers:
         variantsargs = lambda w: [merge_callers_args[w.samples]],
         ver_gatk = config['tools']['gatk3']['version'],
         rname = 'MergeSomaticCallers',
-        tmpdir = config['input_params']['tmpdisk'],
+        set_tmp = set_tmp(),
     threads: 4
     envmodules:
         config['tools']['gatk3']['modname']
@@ -164,8 +163,7 @@ rule somatic_merge_callers:
     # Setups temporary directory for
     # intermediate files with built-in 
     # mechanism for deletion on exit
-    tmp=$(mktemp -d -p "{params.tmpdir}")
-    trap 'rm -rf "${{tmp}}"' EXIT
+    {params.set_tmp}
 
     if [ ! -d "$(dirname {output.mergedvcf})" ]; then
       mkdir -p "$(dirname {output.mergedvcf})"

--- a/workflow/rules/somatic_snps.paired.smk
+++ b/workflow/rules/somatic_snps.paired.smk
@@ -115,7 +115,7 @@ rule strelka:
         basedir = BASEDIR,
         ver_strelka = config['tools']['strelka']['version'],
         rname = 'strelka',
-        tmpdir = config['input_params']['tmpdisk'],
+        set_tmp = set_tmp(),
     envmodules:
         config['tools']['strelka']['modname'],
         config['tools']['gatk3']['modname'],
@@ -132,8 +132,7 @@ rule strelka:
     # Setups temporary directory for
     # intermediate files with built-in 
     # mechanism for deletion on exit
-    tmp=$(mktemp -d -p "{params.tmpdir}")
-    trap 'rm -rf "${{tmp}}"' EXIT
+    {params.set_tmp}
 
     workdir={params.basedir}
     myoutdir="$(dirname {output.vcf})/{wildcards.samples}/{wildcards.chroms}"
@@ -179,7 +178,7 @@ rule strelka_filter:
         ver_gatk = config['tools']['gatk4']['version'],
         ver_bcftools = config['tools']['bcftools']['version'],
         rname = 'strelka_filter',
-        tmpdir = config['input_params']['tmpdisk']
+        set_tmp = set_tmp()
     threads: 4
     envmodules:
         config['tools']['gatk4']['modname'],
@@ -190,8 +189,7 @@ rule strelka_filter:
     # Setups temporary directory for
     # intermediate files with built-in 
     # mechanism for deletion on exit
-    tmp=$(mktemp -d -p "{params.tmpdir}")
-    trap 'rm -rf "${{tmp}}"' EXIT
+    {params.set_tmp}
 
     gatk SelectVariants \\
         -R {params.genome} \\
@@ -233,7 +231,7 @@ rule mutect_paired:
         dbsnp_cosmic = config['references']['DBSNP_COSMIC'],
         ver_mutect = config['tools']['mutect']['version'],
         rname = 'mutect',
-        tmpdir = config['input_params']['tmpdisk']
+        set_tmp = set_tmp(),
     envmodules:
         config['tools']['mutect']['modname']
     container:
@@ -242,8 +240,7 @@ rule mutect_paired:
     # Setups temporary directory for
     # intermediate files with built-in 
     # mechanism for deletion on exit
-    tmp=$(mktemp -d -p "{params.tmpdir}")
-    trap 'rm -rf "${{tmp}}"' EXIT
+    {params.set_tmp}
 
     if [ ! -d "$(dirname {output.vcf})" ]; then mkdir -p "$(dirname {output.vcf})"; fi
     
@@ -275,7 +272,7 @@ rule mutect_filter:
         ver_gatk = config['tools']['gatk4']['version'],
         ver_bcftools = config['tools']['bcftools']['version'],
         rname = 'mutect_filter',
-        tmpdir = config['input_params']['tmpdisk'],
+        set_tmp = set_tmp(),
     threads: 4
     envmodules:
         config['tools']['gatk4']['modname'],
@@ -286,8 +283,7 @@ rule mutect_filter:
     # Setups temporary directory for
     # intermediate files with built-in 
     # mechanism for deletion on exit
-    tmp=$(mktemp -d -p "{params.tmpdir}")
-    trap 'rm -rf "${{tmp}}"' EXIT
+    {params.set_tmp}
 
     gatk SelectVariants \\
         -R {params.genome} \\
@@ -363,7 +359,7 @@ rule vardict_filter:
         ver_gatk = config['tools']['gatk4']['version'],
         ver_bcftools = config['tools']['bcftools']['version'],
         rname = 'vardict',
-        tmpdir = config['input_params']['tmpdisk'],
+        set_tmp = set_tmp(),
     threads: 4
     envmodules:
         config['tools']['bcftools']['modname'],
@@ -374,8 +370,7 @@ rule vardict_filter:
     # Setups temporary directory for
     # intermediate files with built-in 
     # mechanism for deletion on exit
-    tmp=$(mktemp -d -p "{params.tmpdir}")
-    trap 'rm -rf "${{tmp}}"' EXIT
+    {params.set_tmp}
 
     bcftools filter \\
         --exclude \'STATUS=\"Germline\" | STATUS=\"LikelyLOH\" | STATUS=\"AFDiff\"\' \\
@@ -414,7 +409,7 @@ rule varscan_paired:
         tumorsample = '{samples}',
         ver_varscan = config['tools']['varscan']['version'],
         rname = 'varscan',
-        tmpdir = config['input_params']['tmpdisk'],
+        tmpdir = set_tmp(),
     threads: 4
     envmodules:
         config['tools']['varscan']['modname'],
@@ -425,8 +420,7 @@ rule varscan_paired:
     # Setups temporary directory for
     # intermediate files with built-in 
     # mechanism for deletion on exit
-    tmp=$(mktemp -d -p "{params.tmpdir}")
-    trap 'rm -rf "${{tmp}}"' EXIT
+    {params.set_tmp}
 
     if [ ! -d "$(dirname {output.vcf})" ]; then mkdir -p "$(dirname {output.vcf})"; fi
     
@@ -476,7 +470,7 @@ rule varscan_filter:
         ver_gatk = config['tools']['gatk4']['version'],
         ver_bcftools = config['tools']['bcftools']['version'],
         rname = 'varscan_filter',
-        tmpdir = config['input_params']['tmpdisk'],
+        set_tmp = set_tmp(),
     threads: 4
     envmodules:
         config['tools']['varscan']['modname'],
@@ -488,8 +482,7 @@ rule varscan_filter:
     # Setups temporary directory for
     # intermediate files with built-in 
     # mechanism for deletion on exit
-    tmp=$(mktemp -d -p "{params.tmpdir}")
-    trap 'rm -rf "${{tmp}}"' EXIT
+    {params.set_tmp}
 
     varscan filter \\
         {input.vcf} \\

--- a/workflow/rules/somatic_snps.paired.smk
+++ b/workflow/rules/somatic_snps.paired.smk
@@ -409,7 +409,7 @@ rule varscan_paired:
         tumorsample = '{samples}',
         ver_varscan = config['tools']['varscan']['version'],
         rname = 'varscan',
-        tmpdir = set_tmp(),
+        set_tmp = set_tmp(),
     threads: 4
     envmodules:
         config['tools']['varscan']['modname'],

--- a/workflow/rules/somatic_snps.tumor_only.smk
+++ b/workflow/rules/somatic_snps.tumor_only.smk
@@ -48,7 +48,7 @@ rule pileup_single:
         ver_gatk = config['tools']['gatk4']['version'],
         chroms = chroms,
         rname = 'pileup',
-        tmpdir = config['input_params']['tmpdisk']
+        set_tmp = set_tmp()
     envmodules:
         config['tools']['gatk4']['modname']
     container:
@@ -57,8 +57,7 @@ rule pileup_single:
     # Setups temporary directory for
     # intermediate files with built-in 
     # mechanism for deletion on exit
-    tmp=$(mktemp -d -p "{params.tmpdir}")
-    trap 'rm -rf "${{tmp}}"' EXIT
+    {params.set_tmp}
 
     gatk --java-options "-Xmx10g -Djava.io.tmpdir=${{tmp}}" GetPileupSummaries \\
         -R {params.genome} \\
@@ -103,7 +102,7 @@ rule mutect_single:
         dbsnp_cosmic = config['references']['DBSNP_COSMIC'],
         ver_mutect = config['tools']['mutect']['version'],
         rname = 'mutect',
-        tmpdir = config['input_params']['tmpdisk']
+        set_tmp = set_tmp()
     envmodules:
         config['tools']['mutect']['modname']
     container:
@@ -112,8 +111,7 @@ rule mutect_single:
     # Setups temporary directory for
     # intermediate files with built-in 
     # mechanism for deletion on exit
-    tmp=$(mktemp -d -p "{params.tmpdir}")
-    trap 'rm -rf "${{tmp}}"' EXIT
+    {params.set_tmp}
 
     if [ ! -d "$(dirname {output.vcf})" ]; then 
         mkdir -p "$(dirname {output.vcf})"
@@ -145,7 +143,7 @@ rule mutect_filter_single:
         ver_gatk = config['tools']['gatk4']['version'],
         ver_bcftools = config['tools']['bcftools']['version'],
         rname = 'mutect_filter',
-        tmpdir = config['input_params']['tmpdisk'],
+        set_tmp = set_tmp(),
     threads: 4
     envmodules:
         config['tools']['gatk4']['modname'],
@@ -156,8 +154,7 @@ rule mutect_filter_single:
     # Setups temporary directory for
     # intermediate files with built-in 
     # mechanism for deletion on exit
-    tmp=$(mktemp -d -p "{params.tmpdir}")
-    trap 'rm -rf "${{tmp}}"' EXIT
+    {params.set_tmp}
 
     gatk SelectVariants \\
         -R {params.genome} \\
@@ -233,7 +230,7 @@ rule vardict_filter_single:
         ver_gatk = config['tools']['gatk4']['version'],
         ver_bcftools = config['tools']['bcftools']['version'],
         rname = 'vardict_filter', 
-        tmpdir = config['input_params']['tmpdisk']
+        set_tmp = set_tmp(),
     threads: 4
     envmodules:
         config['tools']['bcftools']['modname'],
@@ -244,8 +241,7 @@ rule vardict_filter_single:
     # Setups temporary directory for
     # intermediate files with built-in 
     # mechanism for deletion on exit
-    tmp=$(mktemp -d -p "{params.tmpdir}")
-    trap 'rm -rf "${{tmp}}"' EXIT
+    {params.set_tmp}
 
     gatk SelectVariants \\
         -R {params.genome} \\
@@ -312,7 +308,7 @@ rule varscan_filter_single:
         ver_varscan = config['tools']['varscan']['version'],
         ver_bcftools = config['tools']['bcftools']['version'],
         rname = 'varscan_filter',
-        tmpdir = config['input_params']['tmpdisk'],
+        set_tmp = set_tmp(),
     threads: 4
     envmodules:
         config['tools']['varscan']['modname'],
@@ -324,8 +320,7 @@ rule varscan_filter_single:
     # Setups temporary directory for
     # intermediate files with built-in 
     # mechanism for deletion on exit
-    tmp=$(mktemp -d -p "{params.tmpdir}")
-    trap 'rm -rf "${{tmp}}"' EXIT
+    {params.set_tmp}
 
     varscan filter \\
         {input.vcf} \\

--- a/workflow/rules/trim_map_preprocess.smk
+++ b/workflow/rules/trim_map_preprocess.smk
@@ -22,7 +22,7 @@ rule bam2fastq:
         genome = config['references']['GENOME'],
         ver_gatk = config['tools']['gatk4']['version'],
         rname = 'bam2fastq',
-        tmpdir = config['input_params']['tmpdisk'],
+        set_tmp = set_tmp()
     envmodules:
         config['tools']['gatk4']['modname']
     container:
@@ -31,8 +31,7 @@ rule bam2fastq:
     # Setups temporary directory for
     # intermediate files with built-in 
     # mechanism for deletion on exit
-    tmp=$(mktemp -d -p "{params.tmpdir}")
-    trap 'rm -rf "${{tmp}}"' EXIT
+    {params.set_tmp}
 
     mkdir -p fastqs
     gatk SamToFastq \\


### PR DESCRIPTION
Fixes #32 

## Changes

- Set the default `tmpdisk` parameter to an empty string in the configfile.
- Created a function `set_tmp()` to insert bash code that sets the base tmp path depending on whether the user has defined `tmpdisk` in the config file, whether `$SLURM_JOBID` is set, and whether `/lscratch` exists. It falls back to `/dev/shm` as the base path. The job's temporary directory is then a random string in the chosen path.
- Each rule that uses tmpdisk calls `set_tmp()` in params to generate the job-specific bash code and runs it as the first step in the shell code.

(At first I accidentally opened this PR against main)