### PR TITLE
ci: github assignee is used by default for auto-add-user-project

### DIFF
--- a/.github/workflows/add_issues_to_user_kanban.yml
+++ b/.github/workflows/add_issues_to_user_kanban.yml
@@ -11,6 +11,4 @@ on:
 jobs:
   add-to-project:
     uses: CCBR/.github/.github/workflows/auto-add-user-project.yml@v0.1.0
-    with:
-      username: ${{ github.event.assignee.login }}
     secrets: inherit


### PR DESCRIPTION
so there's no need to specify it in the calling workflow