### PR TITLE
Prepare to release v3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
   - Use `--rerun--incomplete` Snakemake argument and fix bed. (#66, @dnousome)
   - Fix final somatic merge (#70, @dnousome)
   - Fix Varscan/Mutect2 output to keep Tumor Normal ordering. (#84, @dnousome)
-  - Reduce memory allocation (#86, @samarth8392)
+  - Reduce memory allocation. (#86, @samarth8392)
   - Provide a more helpful error message when `xavier` is called with no arguments. (#75, @kelly-sovacool)
 - Documentation improvements: (#78, @kelly-sovacool)
   - Document the release process for developers. (#63, @kelly-sovacool)
   - Create `CITATION.cff` to describe how to cite XAVIER. (#68, @kelly-sovacool)
-- Sync GitHub Actions with with other CCBR pipelines. (#65, #67, @kelly-sovacool; #73, @kopardev)
+- Sync GitHub Actions with other CCBR pipelines. (#65, #67, @kelly-sovacool; #73, @kopardev)
 
 ## XAVIER 3.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,22 @@
-## development version
+## XAVIER 3.0.3
 
-- Create `CITATION.cff` to describe how to cite XAVIER. (#68, @kelly-sovacool)
-- Provide a more helpful error message when `xavier` is called with no arguments. (#75, @kelly-sovacool)
-- Minor documentation improvements. (#78, @kelly-sovacool)
+- Bug fixes:
+  - Use `--rerun--incomplete` Snakemake argument and fix bed. (#66, @dnousome)
+  - Fix final somatic merge (#70, @dnousome)
+  - Fix Varscan/Mutect2 output to keep Tumor Normal ordering. (#84, @dnousome)
+  - Fix issue #85 (#86, @samarth8392)
+  - Provide a more helpful error message when `xavier` is called with no arguments. (#75, @kelly-sovacool)
+- Documentation improvements: (#78, @kelly-sovacool)
+  - Document the release process for developers. (#63, @kelly-sovacool)
+  - Create `CITATION.cff` to describe how to cite XAVIER. (#68, @kelly-sovacool)
+- Sync GitHub Actions with with other CCBR pipelines. (#65, #67, @kelly-sovacool; #73, @kopardev)
 
-## v3.0.2
+## XAVIER 3.0.2
 
 - Documentation updates for GUI and other genome references
 - Additional IUPAC changes to play nice with GATK tools (non ACGTN codes convert to N)
 
-## v3.0.1
+## XAVIER 3.0.1
 
 Hotfixes for all!
 
@@ -17,7 +24,7 @@ Hotfixes for all!
 - Fixed spooker/runner calls for run info
 - Fixed vcf2maf which missed the Intersection of calls
 
-## v3.0.0
+## XAVIER 3.0.0
 
 - added [FRCE](https://ncifrederick.cancer.gov/staff/frce/welcome) support.
 - adding `$triggeroptions` to _snakemake_ cli.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
   - Use `--rerun--incomplete` Snakemake argument and fix bed. (#66, @dnousome)
   - Fix final somatic merge (#70, @dnousome)
   - Fix Varscan/Mutect2 output to keep Tumor Normal ordering. (#84, @dnousome)
-  - Fix issue #85 (#86, @samarth8392)
+  - Reduce memory allocation (#86, @samarth8392)
   - Provide a more helpful error message when `xavier` is called with no arguments. (#75, @kelly-sovacool)
 - Documentation improvements: (#78, @kelly-sovacool)
   - Document the release process for developers. (#63, @kelly-sovacool)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,5 +32,5 @@ url: https://ccbr.github.io/XAVIER/
 repository-code: https://github.com/CCBR/XAVIER
 license: MIT
 type: software
-version: 3.0.2
-date-released: 2023-12-19
+version: 3.0.3
+date-released: 2024-07-11

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -7,5 +7,5 @@ import os, sys
 # across python2 and python3.
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
-# Ground source of truth for version information
-version = "v3.0.2-dev"
+# Single source for version information
+version = "3.0.3"


### PR DESCRIPTION
## Changes

The changelog was missing descriptions for various PRs since v3.0.2, so I added those in. @dnousome please take a look and edit as needed. In the future if you and Samarth could add a line to the changelog every time you open a PR that contains a user-facing change (i.e. a bug fix, a new feature, performance enhancement, or documentation improvement), that would be great so the changelog will always be up to date.

I also updated the version number to prepare for the release.

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
