### PR TITLE
docs: rename GUI doc header in mkdocs.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## development version
 
 - You can now cite XAVIER with the DOI [10.5281/zenodo.12727315](https://doi.org/10.5281/zenodo.12727315). (#88, @kelly-sovacool)
+- Minor documentation improvements. (#92, @kelly-sovacool)
 
 ## XAVIER 3.0.3
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,11 +98,11 @@ markdown_extensions:
 # Page Tree
 nav:
   - About: index.md
-  - Getting Started: usage/gui.md
   - Command Line:
       - xavier run: usage/run.md
       - xavier unlock: usage/unlock.md
       - xavier cache: usage/cache.md
+  - Graphical Interface: usage/gui.md
   - Pipeline Details:
       - Overview: pipeline-details/overview.md
       - Methods: pipeline-details/methods.md


### PR DESCRIPTION
## Changes

rename the header for the GUI doc to make it easier to find in the website

## Issues

related to #91

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
