### PR TITLE
docs: Removed betterem extension from mkdocs.yml to improve rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - You can now cite XAVIER with the DOI [10.5281/zenodo.12727315](https://doi.org/10.5281/zenodo.12727315). (#88, @kelly-sovacool)
 - Minor documentation improvements. (#92, @kelly-sovacool)
+- Minor documentation rendering improvements (#93, @samarth8392)
 
 ## XAVIER 3.0.3
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,8 +70,6 @@ markdown_extensions:
       permalink: true
   - pymdownx.arithmatex:
       generic: true
-  - pymdownx.betterem:
-      smart_enable: all
   - pymdownx.caret
   - pymdownx.critic
   - pymdownx.details


### PR DESCRIPTION
## Changes

Removed `pymdownx.betterem` extension from `mkdocs.yml` file to improve the XAVIER rendering on the documentation website. 

## Issues

Related to #93.

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
