### PR TITLE
chore: specify ccbr_tools version v0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "argparse",
-    "ccbr_tools@git+https://github.com/CCBR/Tools",
+    "ccbr_tools@git+https://github.com/CCBR/Tools@v0.1.0",
     "Click >= 8.1.3",
     "PySimpleGui < 5",
     "snakemake >= 7.32, < 8",


### PR DESCRIPTION
Specify ccbr_tools version v0.1.0 as a dependency, rather than the default branch
