### PR TITLE
fix: upgrade multiqc docker with PYTHONPATH unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## XAVIER development version
-- Bug fixes:
-  - Fix minor bug in assess_significance.R script associated with rule freec_exome_somatic (#120, @samarth8392)
-  
+
+- Fix minor bug in `assess_significance.R` script associated with rule `freec_exome_somatic`. (#120, @samarth8392)
+- Fix bug in multiqc docker container, which caused an error when running xavier from ccbrpipeliner/7. (#123, @kelly-sovacool)
+
 ## XAVIER 3.1.1
 
 - New contributing guide available on GitHub and the documentation website. (#114, @kelly-sovacool)

--- a/config/containers/images.json
+++ b/config/containers/images.json
@@ -8,7 +8,7 @@
         "fastqvalidator": "docker://nciccbr/ccbr_fastqvalidator:v0.1.0",
         "kraken": "docker://nciccbr/ccbr_kraken_v2.1.1:v0.0.1",
         "miniconda": "docker://continuumio/miniconda3:4.9.2",
-        "multiqc": "docker://nciccbr/ccbr_multiqc_1.15:v1",
+        "multiqc": "docker://nciccbr/ccbr_multiqc_1.15:v2",
         "picard": "docker://nciccbr/ccbr_picard:v0.0.1",
         "python": "docker://nciccbr/ccbr_python:v0.0.1",
         "qualimap": "docker://nciccbr/ccbr_qualimap:v0.0.1"


### PR DESCRIPTION
## Changes

upgrade the multiqc docker to use the newer base v7, which has PYTHONPATH unset

## Issues

depends on https://github.com/CCBR/Dockers/pull/39

fixes #122

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
