### PR TITLE
Fix sample discovery when `tumor-only` run without pairs file; minor issue with `pairs.tsv` in test dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## XAVIER development version
 
+- Fixed a bug where tumor-only and unpaired runs could fail during Snakefile parsing (#174, @samarth8392)
+- Fixed the sample names in `pairs.tsv` in test/data folder which causes run with test data to fail (#174, @samarth8392)
 ## XAVIER 3.2.1
 
 - Added separate variable for control-freec genome fasta file (#169, @samarth8392)

--- a/tests/data/pairs.tsv
+++ b/tests/data/pairs.tsv
@@ -1,2 +1,2 @@
 Normal	Tumor
-WES_NC_N_1_0.25	WES_NC_T_1_0.25
+WES_NC_N_1_sub	WES_NC_T_1_sub

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -270,31 +270,66 @@ VCF2MAF_WRAPPER=config['scripts']['vcf2maf_wrapper']
 SOBDetector_out=os.path.join(BASEDIR,"ffpe_filter","sobdetector")
 SOBDetector_JARFILE=os.path.join(SOBDetector_out, "jarfile","SOBDetector_v1.0.2.jar")
 
-name_symlinks=[]
+name_symlinks = []
+
+# FASTQ mode
 if fqs_found:
-    name_suffix=".R[1,2].fastq.gz"
-    if not os.path.exists(input_fqdir):
-        # print("making"+output_fqdir)
-        os.makedirs(input_fqdir)
-        name_symlinks=_sym_safe_(fqs_found, input_fqdir)
-    else:
-        name_symlinks=glob.glob(os.path.join(input_fqdir,'*.fastq.gz'))
+    name_suffix = r"\.R[12]\.fastq\.gz$"
+
+    # Ensure input_fqdir exists
+    os.makedirs(input_fqdir, exist_ok=True)
+
+    # Prefer existing symlinks if present
+    name_symlinks = glob.glob(os.path.join(input_fqdir, "*.fastq.gz"))
+
+    # Harden: if directory exists but is empty, (re)populate it
+    if not name_symlinks:
+        name_symlinks = _sym_safe_(fqs_found, input_fqdir)
+
+# BAM mode
 elif bams_found:
-    name_suffix=".input.bam"
-    if not os.path.exists(input_bamdir):
-        os.makedirs(input_bamdir)
-    if (len(os.listdir(input_bamdir))==0):
-        bam_symlinks=_sym_safe_(bams_found, input_bamdir)
-    name_symlinks=glob.glob(os.path.join(input_bamdir,'*.input.bam'))
+    name_suffix = r"\.input\.bam$"
+
+    os.makedirs(input_bamdir, exist_ok=True)
+    name_symlinks = glob.glob(os.path.join(input_bamdir, "*.input.bam"))
+
+    if not name_symlinks:
+        _ = _sym_safe_(bams_found, input_bamdir)
+        name_symlinks = glob.glob(os.path.join(input_bamdir, "*.input.bam"))
+
+# Nothing found
 else:
-    raise NameError("""\n\tFatal: No relevant files found in the BAM or FASTQ directory!
+    raise NameError(
+        """\n\tFatal: No relevant files found in the BAM or FASTQ directory!
         FASTQ source path provided: {}
         BAM source path provided: {}
         Folders should contain files ending with '.fastq.gz' or '.bam' respectively.
         """.format(fq_source, bam_source, sys.argv[0])
     )
 
-samples = set([re.sub(name_suffix,"",os.path.basename(fname)) for fname in name_symlinks]) ## Only returns paired fqs
+# Derive sample names
+samples = set([
+    re.sub(name_suffix, "", os.path.basename(fname))
+    for fname in name_symlinks
+])
+
+# Extra hardening: fail early with a more actionable message
+if not samples:
+    raise NameError(
+        """\n\tFatal: No samples could be inferred from discovered inputs.
+        FASTQ_SOURCE: {}
+        BAM_SOURCE: {}
+        input_fqdir: {}
+        input_bamdir: {}
+        Found FASTQs: {}
+        Found BAMs: {}
+        Note: if input_files/fastq or input_files/bam exists but is empty,
+        populate it or delete it and rerun.
+        """.format(
+            fq_source, bam_source, input_fqdir, input_bamdir,
+            len(fqs_found), len(bams_found), sys.argv[0]
+        )
+    )
 
 pairs_file = config['input_params']['PAIRS_FILE']
 


### PR DESCRIPTION
## Changes

XAVIER could fail at Snakefile parse time with:
`Fatal: Either a valid pairs file or sample names must be provided.`
`Sample names provided: set()`

even when valid *.fastq.gz inputs were provided and tumor-only mode should have proceeded.

Root cause

Sample discovery depends on name_symlinks, which is normally created by _sym_safe_() symlinking discovered inputs into:
input_files/fastq/ (FASTQ mode) or
input_files/bam/ (BAM mode)

However, the Snakefile logic previously did this:
If input_files/fastq existed, it only globbed input_files/fastq/*.fastq.gz and did not run _sym_safe_() again.
If the directory existed but was empty (e.g., from a partial init/failed run/manual mkdir), then name_symlinks=[] → samples=set() → read_pairsfile() raised the fatal error before any rules executed.

## Issues

Harden sample discovery to repopulate symlinks when the input directory exists but contains no files:
Always os.makedirs(input_fqdir, exist_ok=True) / os.makedirs(input_bamdir, exist_ok=True)
Prefer existing symlinks when present
If globbing the directory returns empty, call _sym_safe_(...) to (re)populate it
Add an early, actionable error message if samples still cannot be inferred

This makes tumor-only runs robust to stale/empty input_files/* directories and prevents parse-time failure.


Fixes #172 
Fixes #173 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
